### PR TITLE
Moves phpunit dependency into require-dev section

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -9,13 +9,13 @@
         }
     ],
     "require": {
-        "phpunit/phpunit": "^8.3",
         "symfony/console": "^4.3"
     },
     "require-dev": {
         "brainmaestro/composer-git-hooks": "^2.8",
         "friendsofphp/php-cs-fixer": "^2.15",
-        "mockery/mockery": "^1.2"
+        "mockery/mockery": "^1.2",
+        "phpunit/phpunit": "^8.3"
     },
     "autoload": {
         "psr-4": {


### PR DESCRIPTION
We currently have phpunit pinned at an older version and we still want to use this lib. 